### PR TITLE
(SIMP-9773) DSIDM doesn't work on user admin group

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,7 @@ fixtures:
     augeas_core:
       repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
       puppet_version: ">= 6.0.0"
+    augeasproviders_core: https://github.com/simp/augeasproviders_core
     compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
     ds389: https://github.com/simp/pupmod-simp-ds389
     firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld

--- a/.pdkignore
+++ b/.pdkignore
@@ -19,6 +19,7 @@
 /spec/fixtures/modules/
 /tmp/
 /vendor/
+/.vendor/
 /convert_report.txt
 /update_report.txt
 .DS_Store

--- a/manifests/instances/accounts.pp
+++ b/manifests/instances/accounts.pp
@@ -93,7 +93,7 @@ class simp_ds389::instances::accounts (
 
 ) {
 
-  $_bootstrap_ldif_content = epp("${module_name}/instance/bootstrap.ldif.epp",
+  $_bootstrap_ldif_content = epp("${module_name}/instances/accounts/bootstrap.ldif.epp",
       {
         base_dn                 => $base_dn,
         root_dn                 => $root_dn,

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -14,6 +14,20 @@ HOSTS:
     box:        generic/oracle8
     hypervisor: <%= hypervisor %>
 
+  client-oel8:
+    roles:
+      - client
+    platform:   el-8-x86_64
+    box:        generic/oracle8
+    hypervisor: <%= hypervisor %>
+
+  client-oel7:
+    roles:
+      - client
+    platform:   el-7-x86_64
+    box:        generic/oracle7
+    hypervisor: <%= hypervisor %>
+
 CONFIG:
   log_level: verbose
   type: aio

--- a/spec/acceptance/suites/default/01_accounts_spec.rb
+++ b/spec/acceptance/suites/default/01_accounts_spec.rb
@@ -58,8 +58,8 @@ describe 'simp_ds389 class' do
         it 'should have the bind account and the users and administrators groups' do
           result = on(server, %(ldapsearch x -w "#{root_pw}" -D "#{root_dn}" -H ldap://#{server_fqdn}  -b "#{base_dn}")).output.strip
           expect(result).to include("#{bind_dn}")
-          expect(result).to include("cn=administrators,ou=Group,#{base_dn}")
-          expect(result).to include("cn=users,ou=Group,#{base_dn}")
+          expect(result).to include("cn=administrators,ou=Groups,#{base_dn}")
+          expect(result).to include("cn=users,ou=Groups,#{base_dn}")
         end
 
       end

--- a/spec/acceptance/suites/default/02_accounts_simp_spec.rb
+++ b/spec/acceptance/suites/default/02_accounts_simp_spec.rb
@@ -79,13 +79,13 @@ describe 'simp_ds389 class' do
       it 'should have the bind account and the users and administrators groups' do
         result = on(server, %(ldapsearch -ZZ -x -w "#{root_pw}" -D "#{root_dn}" -H ldap://#{server_fqdn}  -b "#{base_dn}")).output.strip
         expect(result).to include("#{bind_dn}")
-        expect(result).to include("cn=administrators,ou=Group,#{base_dn}")
-        expect(result).to include("cn=users,ou=Group,#{base_dn}")
+        expect(result).to include("cn=administrators,ou=Groups,#{base_dn}")
+        expect(result).to include("cn=users,ou=Groups,#{base_dn}")
       end
 
       it 'should get results with the bind account' do
         result = on(server, %(ldapsearch -ZZ -x -w "#{bind_pw}" -D "#{bind_dn}" -H ldap://#{server_fqdn}  -b "#{base_dn}")).output.strip
-        expect(result).to include("cn=users,ou=Group,#{base_dn}")
+        expect(result).to include("cn=users,ou=Groups,#{base_dn}")
       end
     end
 
@@ -118,7 +118,7 @@ describe 'simp_ds389 class' do
         it 'should be able to connect using the bind DN and password' do
           # LDAP server parameters are set in /etc/openldap/ldap.conf by simp_openldap
           result = on(client, "ldapsearch -D #{bind_dn} -w #{bind_pw}")
-          expect(result.output).to match(/dn: cn=users,ou=Group,/)
+          expect(result.output).to match(/dn: cn=users,ou=Groups,/)
         end
 
       end

--- a/spec/classes/instances/expected/accounts_bootstrap.txt
+++ b/spec/classes/instances/expected/accounts_bootstrap.txt
@@ -2,8 +2,8 @@ dn: dc=test,dc=org
 dc: test
 objectClass: top
 objectClass: domain
-aci: (targetattr = "aci")(version 3.0;acl "Admins can manage ACIs"; allow (write) groupdn="ldap:///cn=Directory Administrators,ou=Group,dc=test,dc=org";)
-aci: (target=ldap:///dc=test,dc=org)(targetattr=*)(version 3.0; acl "Directory Administrators"; allow(write) groupdn = "ldap:///cn=Directory Administrators,ou=Group,dc=test,dc=org";)
+aci: (targetattr = "aci")(version 3.0;acl "Admins can manage ACIs"; allow (write) groupdn="ldap:///cn=Directory Administrators,ou=Groups,dc=test,dc=org";)
+aci: (target=ldap:///dc=test,dc=org)(targetattr=*)(version 3.0; acl "Directory Administrators"; allow(write) groupdn = "ldap:///cn=Directory Administrators,ou=Groups,dc=test,dc=org";)
 
 dn: cn=Directory Administrators,dc=test,dc=org
 cn: Directory Administrators
@@ -67,8 +67,8 @@ ipHostNumber: 127.0.0.1
 cn: localhost.localdomain
 cn: localhost
 
-dn: ou=Group,dc=test,dc=org
-ou: Group
+dn: ou=Groups,dc=test,dc=org
+ou: Groups
 objectClass: top
 objectClass: organizationalUnit
 aci: (targetattr!="userpassword || aci")(version 3.0; acl "Enable Authenticated Group Read Access"; allow (read, search, compare) userdn="ldap:///all";)
@@ -82,15 +82,17 @@ aci: (targetattr = "givenname || sn || cn || displayname || title || initials ||
 aci: (targetattr = "userpassword")(version 3.0; acl "selfservice:Self can write own password"; allow (write) userdn="ldap:///self";)
 aci: (targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can manage their own X.509 certificates";allow (write) userdn = "ldap:///self";)
 
-dn: cn=users,ou=Group,dc=test,dc=org
+dn: cn=users,ou=Groups,dc=test,dc=org
 objectClass: groupOfUniqueNames
+objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
 cn: users
 gidNumber: 666
 
-dn: cn=administrators,ou=Group,dc=test,dc=org
+dn: cn=administrators,ou=Groups,dc=test,dc=org
 objectClass: groupOfUniqueNames
+objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
 cn: administrators

--- a/templates/instance/bootstrap.ldif.epp
+++ b/templates/instance/bootstrap.ldif.epp
@@ -92,6 +92,7 @@ aci: (targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can man
 
 dn: cn=users,ou=Groups,<%= $base_dn %>
 objectClass: groupOfNames
+objectClass: groupOfUniqueNames
 objectClass: posixGroup
 objectClass: top
 objectClass: nsMemberOf
@@ -100,6 +101,7 @@ gidNumber: <%= $users_group_id %>
 
 dn: cn=administrators,ou=Groups,<%= $base_dn %>
 objectClass: groupOfUniqueNames
+objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
 objectClass: nsMemberOf

--- a/templates/instance/bootstrap.ldif.epp
+++ b/templates/instance/bootstrap.ldif.epp
@@ -91,9 +91,10 @@ aci: (targetattr = "userpassword")(version 3.0; acl "selfservice:Self can write 
 aci: (targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can manage their own X.509 certificates";allow (write) userdn = "ldap:///self";)
 
 dn: cn=users,ou=Groups,<%= $base_dn %>
-objectClass: groupOfUniqueNames
+objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
+objectClass: nsMemberOf
 cn: users
 gidNumber: <%= $users_group_id %>
 
@@ -101,6 +102,7 @@ dn: cn=administrators,ou=Groups,<%= $base_dn %>
 objectClass: groupOfUniqueNames
 objectClass: posixGroup
 objectClass: top
+objectClass: nsMemberOf
 cn: administrators
 gidNumber: <%= $administrators_group_id %>
 

--- a/templates/instance/bootstrap.ldif.epp
+++ b/templates/instance/bootstrap.ldif.epp
@@ -10,8 +10,8 @@ dn: <%= $base_dn %>
 dc: <%= split(split($base_dn, ',')[0], /(?i:dc=)/)[-1] %>
 objectClass: top
 objectClass: domain
-aci: (targetattr = "aci")(version 3.0;acl "Admins can manage ACIs"; allow (write) groupdn="ldap:///cn=Directory Administrators,ou=Group,<%= $base_dn %>";)
-aci: (target=ldap:///<%= $base_dn %>)(targetattr=*)(version 3.0; acl "Directory Administrators"; allow(write) groupdn = "ldap:///cn=Directory Administrators,ou=Group,<%= $base_dn %>";)
+aci: (targetattr = "aci")(version 3.0;acl "Admins can manage ACIs"; allow (write) groupdn="ldap:///cn=Directory Administrators,ou=Groups,<%= $base_dn %>";)
+aci: (target=ldap:///<%= $base_dn %>)(targetattr=*)(version 3.0; acl "Directory Administrators"; allow(write) groupdn = "ldap:///cn=Directory Administrators,ou=Groups,<%= $base_dn %>";)
 
 dn: cn=Directory Administrators,<%= $base_dn %>
 cn: Directory Administrators
@@ -75,8 +75,8 @@ ipHostNumber: 127.0.0.1
 cn: localhost.localdomain
 cn: localhost
 
-dn: ou=Group,<%= $base_dn %>
-ou: Group
+dn: ou=Groups,<%= $base_dn %>
+ou: Groups
 objectClass: top
 objectClass: organizationalUnit
 aci: (targetattr!="userpassword || aci")(version 3.0; acl "Enable Authenticated Group Read Access"; allow (read, search, compare) userdn="ldap:///all";)
@@ -90,14 +90,14 @@ aci: (targetattr = "givenname || sn || cn || displayname || title || initials ||
 aci: (targetattr = "userpassword")(version 3.0; acl "selfservice:Self can write own password"; allow (write) userdn="ldap:///self";)
 aci: (targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can manage their own X.509 certificates";allow (write) userdn = "ldap:///self";)
 
-dn: cn=users,ou=Group,<%= $base_dn %>
+dn: cn=users,ou=Groups,<%= $base_dn %>
 objectClass: groupOfUniqueNames
 objectClass: posixGroup
 objectClass: top
 cn: users
 gidNumber: <%= $users_group_id %>
 
-dn: cn=administrators,ou=Group,<%= $base_dn %>
+dn: cn=administrators,ou=Groups,<%= $base_dn %>
 objectClass: groupOfUniqueNames
 objectClass: posixGroup
 objectClass: top

--- a/templates/instances/accounts/bootstrap.ldif.epp
+++ b/templates/instances/accounts/bootstrap.ldif.epp
@@ -91,11 +91,10 @@ aci: (targetattr = "userpassword")(version 3.0; acl "selfservice:Self can write 
 aci: (targetattr = "usercertificate")(version 3.0;acl "selfservice:Users can manage their own X.509 certificates";allow (write) userdn = "ldap:///self";)
 
 dn: cn=users,ou=Groups,<%= $base_dn %>
-objectClass: groupOfNames
 objectClass: groupOfUniqueNames
+objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
-objectClass: nsMemberOf
 cn: users
 gidNumber: <%= $users_group_id %>
 
@@ -104,7 +103,6 @@ objectClass: groupOfUniqueNames
 objectClass: groupOfNames
 objectClass: posixGroup
 objectClass: top
-objectClass: nsMemberOf
 cn: administrators
 gidNumber: <%= $administrators_group_id %>
 


### PR DESCRIPTION
 -  dsidm does not recognize posixgroups or groups unless
       they are in the ou=Groups,<base_dn>  ou.  They  also
       need to have an objectClass of groupOfNames.  This
       updates the bootstrap files to create the users and
       administrators groups with those attributes.
    
    SIMP-9773 #close

