### PR TITLE
(SIMP-MAINT) Static asset update

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,24 +3,22 @@
 ---
 fixtures:
   repositories:
-    augeas_core:
-      repo: https://github.com/simp/pupmod-puppetlabs-augeas_core.git
-      puppet_version: ">= 6.0.0"
-    augeasproviders_core: https://github.com/simp/augeasproviders_core
-    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup
-    ds389: https://github.com/simp/pupmod-simp-ds389
-    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld
-    pki: https://github.com/simp/pupmod-simp-pki
-    simplib: https://github.com/simp/pupmod-simp-simplib
-    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld
-    stdlib: https://github.com/simp/puppetlabs-stdlib
+    augeas_core:  https://github.com/simp/pupmod-puppetlabs-augeas_core.git
+    augeasproviders_core: https://github.com/simp/augeasproviders_core.git
+    compliance_markup: https://github.com/simp/pupmod-simp-compliance_markup.git
+    ds389: https://github.com/simp/pupmod-simp-ds389.git
+    firewalld: https://github.com/simp/pupmod-voxpupuli-firewalld.git
+    pki: https://github.com/simp/pupmod-simp-pki.git
+    simplib: https://github.com/simp/pupmod-simp-simplib.git
+    simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
+    stdlib: https://github.com/simp/puppetlabs-stdlib.git
     vox_selinux:
-      repo: https://github.com/simp/pupmod-voxpupuli-selinux
+      repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master
-    selinux: https://github.com/simp/pupmod-simp-selinux
+    selinux: https://github.com/simp/pupmod-simp-selinux.git
 # for testing on the client
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap
-    simp_options: https://github.com/simp/pupmod-simp-simp_options
+    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
+    simp_options: https://github.com/simp/pupmod-simp-simp_options.git
   symlinks:
     simp_ds389: "#{source_dir}"
 

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -11,13 +11,11 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.40    TBD
-# PE 2018.1     5.5      2.40    2021-01 (LTS overlap)
-# PE 2019.8     6.18     2.5     2022-12 (LTS)
+# PE 2019.8     6.22     2.5     2022-12 (LTS)
+# PE 2021.Y     7.x      2.7     Quarterly updates
 #
-# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ==============================================================================
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
@@ -111,12 +109,9 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 6.18 [SIMP 6.5/PE 2019.8]'
-            puppet_version: '~> 6.18.0'
+          - label: 'Puppet 6.22 [SIMP 6.6/PE 2019.8]'
+            puppet_version: '~> 6.22.1'
             ruby_version: '2.5'
-          - label: 'Puppet 5.5 [SIMP 6.4/PE 2018.1]'
-            puppet_version: '~> 5.5.22'
-            ruby_version: '2.4'
           - label: 'Puppet 7.x'
             puppet_version: '~> 7.0'
             ruby_version: '2.7'

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
-# NOTE: This file is managed by puppetsync.  Make sure any changes are
-#       reflected in the control repo.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 .*.sw?
 .yardoc
 .idea/
@@ -10,6 +14,7 @@ dist
 /.rspec_system
 /.vagrant
 /.bundle
+/.vendor
 /vendor
 /junit
 /log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,9 +13,7 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby    EOL
-# SIMP 6.4      5.5      2.4.10  TBD
-# PE 2018.1     5.5      2.4.10  2021-01 (LTS overlap)
-# PE 2019.8     6.18     2.5.7   2022-12 (LTS)
+# PE 2019.8     6.22     2.5.7   2022-12 (LTS)
 ---
 
 stages:
@@ -32,7 +30,7 @@ variables:
   # anchors.  If it is still `UNDEFINED`, all the other setting from the job's
   # anchor are also missing.
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
-  BUNDLER_VERSION:   '1.17.1'
+  BUNDLER_VERSION:   '2.2.19'
   SIMP_MATRIX_LEVEL: '1'
   SIMP_FORCE_RUN_MATRIX: 'no'
 
@@ -234,7 +232,7 @@ variables:
 .pup_6_pe: &pup_6_pe
   image: 'ruby:2.5'
   variables:
-    PUPPET_VERSION: '6.18.0'
+    PUPPET_VERSION: '6.22.1'
     BEAKER_PUPPET_COLLECTION: 'puppet6'
     MATRIX_RUBY_VERSION: '2.5'
 
@@ -310,6 +308,7 @@ pup-lint:
 
 # Unit Tests
 #-----------------------------------------------------------------------
+
 pup6.x-unit:
   <<: *pup_6_x
   <<: *unit_tests

--- a/.pdkignore
+++ b/.pdkignore
@@ -1,5 +1,15 @@
+# .pdkignore masks files from inclusion by `pdk build`.
+#
+# It is used by CI when building modules to publish to the Puppet Forge and to
+# mask symlinks from the `pdk build` test in the module's RELENG checks.
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
+.*.sw?
 .git/
-.*.sw[op]
 .metadata
 .yardoc
 .yardwarns
@@ -15,8 +25,7 @@
 /junit/
 /log/
 /pkg/
-/spec/fixtures/manifests/
-/spec/fixtures/modules/
+/dist/
 /tmp/
 /vendor/
 /.vendor/
@@ -31,8 +40,12 @@
 /Gemfile
 /.gitattributes
 /.gitignore
+/.github/
 /.gitlab-ci.yml
 /.pdkignore
+/.puppet-lint.rc
+/.sync.yml
+/.pmtignore
 /Rakefile
 /rakelib/
 /.rspec
@@ -41,3 +54,4 @@
 /.yardopts
 /spec/
 /.vscode/
+/tests/

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format documentation
 --color
 --fail-fast
--I ./spec/rspec_formatters

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,9 @@
+# ------------------------------------------------------------------------------
+#         NOTICE: **This file is maintained with puppetsync**
+#
+# This file is automatically updated as part of a puppet module baseline.
+# The next baseline sync will overwrite any local changes made to this file.
+# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
@@ -5,12 +11,12 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.18'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 6.22'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
   gem 'rspec'
-  gem 'rspec-puppet', '~> 2.8.0'
+  gem 'rspec-puppet'
   gem 'hiera-puppet-helper'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
@@ -18,8 +24,9 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['> 5.11', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
+  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 
 group :development do
@@ -31,7 +38,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.0', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.23.2', '< 2']
 end
 
 # Evaluate extra gemfiles if they exist

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.4.0 < 7.0.0"
+      "version_requirement": ">= 6.6.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -52,7 +52,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.12.0 < 8.0.0"
+      "version_requirement": ">= 6.22.1 < 8.0.0"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,6 +20,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Update to reflect last 2 static asset pushes
* Made sure all fixture URLs end in '.git', as not all private
  GitHub mirrors allow shortened URLs
* Fail acceptance tests if no examples are executed.

[SIMP-9666] #comment pupmod-simp-simp_ds389 acceptance tests configured

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666