### PR TITLE
(SIMP-10409) Fixed sudoers template entries

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -12,6 +12,7 @@ fixtures:
     simplib: https://github.com/simp/pupmod-simp-simplib.git
     simp_firewalld: https://github.com/simp/pupmod-simp-simp_firewalld.git
     stdlib: https://github.com/simp/puppetlabs-stdlib.git
+    systemd: https://github.com/simp/puppet-systemd.git
     vox_selinux:
       repo: https://github.com/simp/pupmod-voxpupuli-selinux.git
       branch: simp-master

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,8 @@
+* Wed Aug 04 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.1.1
+- Fixed the bootstrap template
+  - Set the SUDOers OU properly
+  - Removed the ignore_local_sudoers option from the sudo defaults for safety
+  - Added the usual batch of sudoers defaults
+
 * Mon May 17 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 0.1.0
 - Initial release

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_ds389",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "simp",
   "summary": "Profile module for SIMP DS389 server",
   "license": "Apache-2.0",

--- a/spec/classes/instances/expected/accounts_bootstrap.txt
+++ b/spec/classes/instances/expected/accounts_bootstrap.txt
@@ -99,7 +99,7 @@ cn: administrators
 gidNumber: 777
 
 dn: ou=SUDOers,dc=test,dc=org
-ou: People
+ou: SUDOers
 objectClass: top
 objectClass: organizationalUnit
 aci: (targetattr!="userpassword || aci")(version 3.0; acl "Enable Host Bind User Read Access"; allow (read, search, compare) userdn="ldap:///cn=myhostAuth,ou=Hosts,dc=test,dc=org";)
@@ -111,11 +111,20 @@ objectClass: sudoRole
 description: Default sudo options
 sudoOrder: 1
 sudoOption: ignore_unknown_defaults
-sudoOption: env_reset
-sudoOption: ignore_dot
-sudoOption: ignore_local_sudoers
-sudoOption: requiretty
-sudoOption: !root_sudo
-sudoOption: use_pty
-sudoOption: lecture=once
+sudoOption: !visiblepw
+sudoOption: always_set_home
+sudoOption: match_group_by_gid
+sudoOption: always_query_group_plugin
 sudoOption: listpw=all
+sudoOption: requiretty
+sudoOption: syslog=authpriv
+sudoOption: !root_sudo
+sudoOption: !umask
+sudoOption: secure_path = /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+sudoOption: env_reset
+sudoOption: env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR"
+sudoOption: env_keep += "LS_COLORS MAIL PS1 PS2 QTDIR USERNAME"
+sudoOption: env_keep += "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION"
+sudoOption: env_keep += "LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC"
+sudoOption: env_keep += "LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS"
+sudoOption: env_keep += "XKB_CHARSET XAUTHORITY"

--- a/templates/instances/accounts/bootstrap.ldif.epp
+++ b/templates/instances/accounts/bootstrap.ldif.epp
@@ -107,7 +107,7 @@ cn: administrators
 gidNumber: <%= $administrators_group_id %>
 
 dn: ou=SUDOers,<%= $base_dn %>
-ou: People
+ou: SUDOers
 objectClass: top
 objectClass: organizationalUnit
 aci: (targetattr!="userpassword || aci")(version 3.0; acl "Enable Host Bind User Read Access"; allow (read, search, compare) userdn="ldap:///<%= $bind_dn %>";)
@@ -119,11 +119,20 @@ objectClass: sudoRole
 description: Default sudo options
 sudoOrder: 1
 sudoOption: ignore_unknown_defaults
-sudoOption: env_reset
-sudoOption: ignore_dot
-sudoOption: ignore_local_sudoers
-sudoOption: requiretty
-sudoOption: !root_sudo
-sudoOption: use_pty
-sudoOption: lecture=once
+sudoOption: !visiblepw
+sudoOption: always_set_home
+sudoOption: match_group_by_gid
+sudoOption: always_query_group_plugin
 sudoOption: listpw=all
+sudoOption: requiretty
+sudoOption: syslog=authpriv
+sudoOption: !root_sudo
+sudoOption: !umask
+sudoOption: secure_path = /usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+sudoOption: env_reset
+sudoOption: env_keep = "COLORS DISPLAY HOSTNAME HISTSIZE INPUTRC KDEDIR"
+sudoOption: env_keep += "LS_COLORS MAIL PS1 PS2 QTDIR USERNAME"
+sudoOption: env_keep += "LANG LC_ADDRESS LC_CTYPE LC_COLLATE LC_IDENTIFICATION"
+sudoOption: env_keep += "LC_MEASUREMENT LC_MESSAGES LC_MONETARY LC_NAME LC_NUMERIC"
+sudoOption: env_keep += "LC_PAPER LC_TELEPHONE LC_TIME LC_ALL LANGUAGE LINGUAS"
+sudoOption: env_keep += "XKB_CHARSET XAUTHORITY"


### PR DESCRIPTION
- Fixed the bootstrap template
  - Set the SUDOers OU properly
  - Removed the ignore_local_sudoers option from the sudo defaults for safety
  - Added the usual batch of sudoers defaults

SIMP-10409 #comment Fixed sudoers template entries