### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -18,7 +18,6 @@ fixtures:
       branch: simp-master
     selinux: https://github.com/simp/pupmod-simp-selinux.git
 # for testing on the client
-    simp_openldap: https://github.com/simp/pupmod-simp-simp_openldap.git
     simp_options: https://github.com/simp/pupmod-simp-simp_options.git
   symlinks:
     simp_ds389: "#{source_dir}"

--- a/spec/acceptance/suites/default/02_accounts_simp_spec.rb
+++ b/spec/acceptance/suites/default/02_accounts_simp_spec.rb
@@ -108,7 +108,6 @@ describe 'simp_ds389 class' do
       context "#{client} connecting to #{server}" do
         let(:client_manifest) do
           <<-EOS
-         include 'simp_openldap::client'
 
          #let vagrant ssh in
          simp_firewalld::rule { "Allow ssh":
@@ -132,7 +131,6 @@ describe 'simp_ds389 class' do
           # Wait for client to be able to connect to the server on the ldaps port.
           wait_for_tcp_from(client, server_fqdn, 636)
 
-          # LDAP server parameters are set in /etc/openldap/ldap.conf by simp_openldap
           result = on(client, "ldapsearch -D #{bind_dn} -w #{bind_pw} -H ldaps://#{server_fqdn}")
           expect(result.output).to match(%r{dn: cn=users,ou=Groups,})
         end


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.