### PR TITLE
Cleanup for 2.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -10,9 +10,9 @@
 #
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
 
@@ -95,10 +95,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 2.0.0
+- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
+- Point `issues_url` at GitHub Issues
+- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
+- Allow newer SIMP module dependencies (see metadata.json diff)
+- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
+- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere
+
 * Wed Dec 10 2025 Mike Riddle <mike@sicura.us> - 1.0.0
 - Removed el7 Support
 - Added el10 support

--- a/Gemfile
+++ b/Gemfile
@@ -13,10 +13,10 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.86.0'
+  gem 'rubocop', '~> 1.87.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
-  gem 'rubocop-rspec', '~> 3.9.0'
+  gem 'rubocop-rspec', '~> 3.10.0'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -13,20 +13,23 @@ gem_sources.each { |gem_source| source gem_source }
 group :syntax do
   gem 'metadata-json-lint'
   gem 'puppet-lint-trailing_comma-check', require: false
-  gem 'rubocop', '~> 1.87.0'
+  gem 'rubocop', '~> 1.86.0'
   gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake', '~> 0.7.0'
-  gem 'rubocop-rspec', '~> 3.10.0'
+  gem 'rubocop-rspec', '~> 3.9.0'
 end
 
 group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
   gem 'hiera-puppet-helper'
-  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   # renovate: datasource=rubygems versioning=ruby
   gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
+  # Temporarily include both openvox and puppet gems until the puppet dependency is removed from other gems
+  ['openvox', 'puppet'].each do |gem_name|
+    gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
+  end
   gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "simp-simp_ds389",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "author": "simp",
   "summary": "Profile module for SIMP DS389 server",
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-simp_ds389",
   "project_page": "https://github.com/simp/pupmod-simp-simp_ds389",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-simp_ds389/issues",
   "tags": [
     "simp",
     "simp_ds389"
@@ -14,7 +14,7 @@
   "dependencies": [
     {
       "name": "simp/ds389",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     },
     {
       "name": "simp/simplib",
@@ -72,8 +72,8 @@
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/centos9.yml
+++ b/spec/acceptance/nodesets/centos9.yml
@@ -1,0 +1,19 @@
+---
+HOSTS:
+  centos9:
+    roles:
+    - default
+    - master
+    - server
+    - el9
+    platform: el-9-x86_64
+    box: generic/centos9s
+    hypervisor: "<%= ENV.fetch('BEAKER_HYPERVISOR', 'vagrant') %>"
+    vagrant_memsize: 2048
+    vagrant_cpus: 2
+    family: centos-cloud/centos-stream-9
+    gce_machine_type: n1-standard-2
+CONFIG:
+  log_level: verbose
+  type: aio
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'openvox8') %>"


### PR DESCRIPTION
## Summary

Cleanup pass to bring this module in line with the current SIMP baseline. No API/behavior changes.

- Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
- Point `issues_url` at GitHub Issues
- Drop end-of-life OS support (CentOS 8, EL7); list EL10 across all supported distros
- Allow newer SIMP module dependencies (see metadata.json diff)
- Sync Gemfile with current puppetsync baseline (adds OpenVox to test gems)
- Drop Puppet 7 / Ruby 2.7 from GitHub Actions; use Ruby 3.2.11 with OpenVox 8 and 3.4.9 elsewhere

## Test plan
- [x] `bundle exec rake metadata_lint` (ruby:3.2 container)
