### PR TITLE
Allow simp-simp_firewalld 2.x

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Thu Jul 02 2026 Steven Pritchard <steve@sicura.us> - 2.0.1
-- Allow simp-simp_firewalld 2.x
+- Allow simp-simp_firewalld 2.x and 3.x
 
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 2.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Thu Jul 02 2026 Steven Pritchard <steve@sicura.us> - 2.0.1
+- Allow simp-simp_firewalld 2.x
+
 * Mon Jun 08 2026 Steven Pritchard <steven.pritchard@gmail.com> - 2.0.0
 - Switch `requirements` from `puppet` to `openvox` (>= 8 < 9)
 - Point `issues_url` at GitHub Issues

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simp_firewalld",
-      "version_requirement": ">= 0.1.3 < 3.0.0"
+      "version_requirement": ">= 0.1.3 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_ds389",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "simp",
   "summary": "Profile module for SIMP DS389 server",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     },
     {
       "name": "simp/simp_firewalld",
-      "version_requirement": ">= 0.1.3 < 2.0.0"
+      "version_requirement": ">= 0.1.3 < 3.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
simp_firewalld 2.0.0 has been released; the `< 2.0.0` cap in metadata.json trips `assert_optional_dependency` in consumers running with current simp_firewalld.

- Widen `simp/simp_firewalld` to `>= 0.1.3 < 3.0.0`
- Bump version to 2.0.1 with CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)